### PR TITLE
Added error checking for size of lookup table

### DIFF
--- a/maglev.go
+++ b/maglev.go
@@ -36,6 +36,10 @@ func (m *Maglev) Add(backend string) error {
 		}
 	}
 
+	if m.m == m.n {
+		return errors.New("Number of backends would be greater than lookup table")
+	}
+
 	m.nodeList = append(m.nodeList, backend)
 	m.n = uint64(len(m.nodeList))
 	m.generatePopulation()


### PR DESCRIPTION
If the number of backends exceeds the size of the lookup table, the maglev algorithm won't work anymore, so I added error checking for that.