### PR TITLE
Update loop condition in maglev.go

### DIFF
--- a/maglev.go
+++ b/maglev.go
@@ -157,7 +157,7 @@ func (m *Maglev) populate() {
 
 	var n uint64
 
-	for { //true
+	for n < m.m { //true
 		for i = 0; i < m.n; i++ {
 			c := m.permutation[i][next[i]]
 			for entry[c] >= 0 {


### PR DESCRIPTION
This works as-is, but I think the outer `for {}` makes the loop look more dangerous than it actually is. Since the real goal is to keep filling entries until `n == m.m`, using `for n < m.m` would make the termination condition explicit and easier to reason about.